### PR TITLE
Move helper functions out of sse4.2 object

### DIFF
--- a/port/port_example.h
+++ b/port/port_example.h
@@ -129,6 +129,10 @@ extern bool Snappy_Uncompress(const char* input_data, size_t input_length,
 // The concatenation of all "data[0,n-1]" fragments is the heap profile.
 extern bool GetHeapProfile(void (*func)(void*, const char*, int), void* arg);
 
+// Determine whether a working accelerated crc32 implementation exists
+// Returns true if AcceleratedCRC32C is safe to call
+bool HasAcceleratedCRC32C();
+
 // Extend the CRC to include the first n bytes of buf.
 //
 // Returns zero if the CRC cannot be extended using acceleration, else returns

--- a/port/port_posix.cc
+++ b/port/port_posix.cc
@@ -8,6 +8,10 @@
 #include <stdio.h>
 #include <string.h>
 
+#if defined(__GNUC__)
+#include <cpuid.h>
+#endif
+
 namespace leveldb {
 namespace port {
 
@@ -47,6 +51,16 @@ void CondVar::SignalAll() {
 
 void InitOnce(OnceType* once, void (*initializer)()) {
   PthreadCall("once", pthread_once(once, initializer));
+}
+
+bool HasAcceleratedCRC32C() {
+#if (__x86_64__ || __i386__) && defined(__GNUC__)
+  unsigned int eax, ebx, ecx, edx;
+  __get_cpuid(1, &eax, &ebx, &ecx, &edx);
+  return (ecx & (1 << 20)) != 0;
+#else
+  return false;
+#endif
 }
 
 }  // namespace port

--- a/port/port_posix.h
+++ b/port/port_posix.h
@@ -152,6 +152,7 @@ inline bool GetHeapProfile(void (*func)(void*, const char*, int), void* arg) {
   return false;
 }
 
+bool HasAcceleratedCRC32C();
 uint32_t AcceleratedCRC32C(uint32_t crc, const char* buf, size_t size);
 
 } // namespace port

--- a/port/port_posix_sse.cc
+++ b/port/port_posix_sse.cc
@@ -19,7 +19,6 @@
 #include <intrin.h>
 #elif defined(__GNUC__) && defined(__SSE4_2__)
 #include <nmmintrin.h>
-#include <cpuid.h>
 #endif
 
 #endif  // defined(LEVELDB_PLATFORM_POSIX_SSE)
@@ -48,20 +47,6 @@ static inline uint64_t LE_LOAD64(const uint8_t *p) {
 
 #endif  // defined(_M_X64) || defined(__x86_64__)
 
-static inline bool HaveSSE42() {
-#if defined(_MSC_VER)
-  int cpu_info[4] = {};
-  __cpuid(cpu_info, 1);
-  return (cpu_info[2] & (1 << 20)) != 0;
-#elif defined(__GNUC__)
-  unsigned int eax, ebx, ecx=0, edx;
-  __get_cpuid(1, &eax, &ebx, &ecx, &edx);
-  return (ecx & (1 << 20)) != 0;
-#else
-  return false;
-#endif
-}
-
 #endif  // defined(LEVELDB_PLATFORM_POSIX_SSE)
 
 // For further improvements see Intel publication at:
@@ -70,10 +55,6 @@ uint32_t AcceleratedCRC32C(uint32_t crc, const char* buf, size_t size) {
 #if !defined(LEVELDB_PLATFORM_POSIX_SSE)
   return 0;
 #else
-  static bool have = HaveSSE42();
-  if (!have) {
-    return 0;
-  }
 
   const uint8_t *p = reinterpret_cast<const uint8_t *>(buf);
   const uint8_t *e = p + size;

--- a/port/port_posix_sse.cc
+++ b/port/port_posix_sse.cc
@@ -50,11 +50,11 @@ static inline uint64_t LE_LOAD64(const uint8_t *p) {
 
 static inline bool HaveSSE42() {
 #if defined(_MSC_VER)
-  int cpu_info[4];
+  int cpu_info[4] = {};
   __cpuid(cpu_info, 1);
   return (cpu_info[2] & (1 << 20)) != 0;
 #elif defined(__GNUC__)
-  unsigned int eax, ebx, ecx, edx;
+  unsigned int eax, ebx, ecx=0, edx;
   __get_cpuid(1, &eax, &ebx, &ecx, &edx);
   return (ecx & (1 << 20)) != 0;
 #else

--- a/port/port_win.cc
+++ b/port/port_win.cc
@@ -32,6 +32,7 @@
 
 #include <windows.h>
 #include <cassert>
+#include <intrin.h>
 
 namespace leveldb {
 namespace port {
@@ -141,6 +142,16 @@ void* AtomicPointer::NoBarrier_Load() const {
 
 void AtomicPointer::NoBarrier_Store(void* v) {
   rep_ = v;
+}
+
+bool HasAcceleratedCRC32C() {
+#if (__x86_64__ || __i386__)
+  int cpu_info[4];
+  __cpuid(cpu_info, 1);
+  return (cpu_info[2] & (1 << 20)) != 0;
+#else
+  return false;
+#endif
 }
 
 }

--- a/port/port_win.h
+++ b/port/port_win.h
@@ -168,6 +168,7 @@ inline bool GetHeapProfile(void (*func)(void*, const char*, int), void* arg) {
   return false;
 }
 
+bool HasAcceleratedCRC32C();
 uint32_t AcceleratedCRC32C(uint32_t crc, const char* buf, size_t size);
 
 }

--- a/util/crc32c.cc
+++ b/util/crc32c.cc
@@ -288,6 +288,10 @@ static inline uint32_t LE_LOAD32(const uint8_t *p) {
 // Determine if the CPU running this program can accelerate the CRC32C
 // calculation.
 static bool CanAccelerateCRC32C() {
+  if (!port::HasAcceleratedCRC32C())
+    return false;
+
+  // Double-check that the accelerated implementation functions correctly.
   // port::AcceleretedCRC32C returns zero when unable to accelerate.
   static const char kTestCRCBuffer[] = "TestCRCBuffer";
   static const char kBufSize = sizeof(kTestCRCBuffer) - 1;


### PR DESCRIPTION
Addresses #4.

As this file is compiled with sse42 flags, it's possible that the feature discovery ends up using an unsupported instruction at runtime.
    
Fix this by adding CanAccelerateCRC32C to the port api, and requiring that it be checked before using AcceleratedCRC32C.