### PR TITLE
Fixes typo

### DIFF
--- a/db/version_set.h
+++ b/db/version_set.h
@@ -376,7 +376,7 @@ class Compaction {
   // Each compaction reads inputs from "level_" and "level_+1"
   std::vector<FileMetaData*> inputs_[2];      // The two sets of inputs
 
-  // State used to check for number of of overlapping grandparent files
+  // State used to check for number of overlapping grandparent files
   // (parent == level_ + 1, grandparent == level_ + 2)
   std::vector<FileMetaData*> grandparents_;
   size_t grandparent_index_;  // Index in grandparent_starts_


### PR DESCRIPTION
“of of” -> “of”

Mirroring downstream change committed in
https://github.com/bitcoin/bitcoin/commit/0a5a6b90bc75a8d75fdff71c9b08abe9b0b96b0a