### PR TITLE
Make {v}snprintf definition dependent on _MSC_VER

### DIFF
--- a/port/port_win.h
+++ b/port/port_win.h
@@ -35,6 +35,9 @@
 #if !(_MSC_VER >= 1900)
 #define snprintf _snprintf
 #endif
+#if (_MSC_VER < 1500) && !defined(vsnprintf)  /* vsnprintf not defined yet & not introduced */
+#define vsnprintf(b,c,f,a) _vsnprintf(b,c,f,a)
+#endif
 #define close _close
 #define fread_unlocked _fread_nolock
 #ifdef _WIN64


### PR DESCRIPTION
`VS2015` already has a definition for `snprintf`. This results into compilation error:

```
D:\work\leveldb-1.20\port/port_win.h(35): note: see previous definition of 'snprintf'
C:\Program Files (x86)\Windows Kits\10\include\10.0.10240.0\ucrt\stdio.h(1927): fatal error C1189: #error:  Macro definition of snprintf conflicts with Standard Library function declaration
```

This patch makes the definition of `snprintf` and `vsnprintf` conditional,
based on the value of the macro `_MSC_VER`