### PR TITLE
Clean up compile-time warnings (gcc 7.1)

### DIFF
--- a/db/memtable.cc
+++ b/db/memtable.cc
@@ -101,7 +101,7 @@ void MemTable::Add(SequenceNumber s, ValueType type,
   p += 8;
   p = EncodeVarint32(p, val_size);
   memcpy(p, value.data(), val_size);
-  assert((p + val_size) - buf == encoded_len);
+  assert(p + val_size == buf + encoded_len);
   table_.Insert(buf);
 }
 

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -20,7 +20,7 @@
 
 namespace leveldb {
 
-static int TargetFileSize(const Options* options) {
+static size_t TargetFileSize(const Options* options) {
   return options->max_file_size;
 }
 

--- a/util/logging.cc
+++ b/util/logging.cc
@@ -49,7 +49,7 @@ bool ConsumeDecimalNumber(Slice* in, uint64_t* val) {
   uint64_t v = 0;
   int digits = 0;
   while (!in->empty()) {
-    char c = (*in)[0];
+    unsigned char c = (*in)[0];
     if (c >= '0' && c <= '9') {
       ++digits;
       const int delta = (c - '0');


### PR DESCRIPTION
* max_file_size was already a size_t, so return that.
* ecx was somehow being listed as used-uninitialized