### PR TITLE
fixup define checks. Cleans up some oopses from #5.

### DIFF
--- a/port/port_posix.cc
+++ b/port/port_posix.cc
@@ -8,7 +8,7 @@
 #include <stdio.h>
 #include <string.h>
 
-#if defined(__GNUC__)
+#if (defined(__x86_64__) || defined(__i386__)) && defined(__GNUC__)
 #include <cpuid.h>
 #endif
 
@@ -54,7 +54,7 @@ void InitOnce(OnceType* once, void (*initializer)()) {
 }
 
 bool HasAcceleratedCRC32C() {
-#if (__x86_64__ || __i386__) && defined(__GNUC__)
+#if (defined(__x86_64__) || defined(__i386__)) && defined(__GNUC__)
   unsigned int eax, ebx, ecx, edx;
   __get_cpuid(1, &eax, &ebx, &ecx, &edx);
   return (ecx & (1 << 20)) != 0;

--- a/port/port_win.cc
+++ b/port/port_win.cc
@@ -145,7 +145,7 @@ void AtomicPointer::NoBarrier_Store(void* v) {
 }
 
 bool HasAcceleratedCRC32C() {
-#if (__x86_64__ || __i386__)
+#if defined(__x86_64__) || defined(__i386__)
   int cpu_info[4];
   __cpuid(cpu_info, 1);
   return (cpu_info[2] & (1 << 20)) != 0;


### PR DESCRIPTION
- use "#if defined(foo)" rather than "#if foo"
- Use the same guard for the cpuid header and the function