### PR TITLE
fix warning -Wsign-compare in ConsumeDecimalNumber, g++ 7.2.0

### DIFF
--- a/util/logging.cc
+++ b/util/logging.cc
@@ -52,7 +52,7 @@ bool ConsumeDecimalNumber(Slice* in, uint64_t* val) {
     unsigned char c = (*in)[0];
     if (c >= '0' && c <= '9') {
       ++digits;
-      const int delta = (c - '0');
+      const uint8_t delta = (c - '0');
       static const uint64_t kMaxUint64 = ~static_cast<uint64_t>(0);
       if (v > kMaxUint64/10 ||
           (v == kMaxUint64/10 && delta > kMaxUint64%10)) {


### PR DESCRIPTION
Warning produced by g++ 7.2.0

This commit fixes the warning by using a uint8_t instead of int for a positive number <10.

Referenced by https://github.com/bitcoin/bitcoin/pull/11525
