### PR TITLE
Remove the deprecated OSMemoryBarrier

### DIFF
--- a/port/atomic_pointer.h
+++ b/port/atomic_pointer.h
@@ -19,14 +19,11 @@
 #define PORT_ATOMIC_POINTER_H_
 
 #include <stdint.h>
-#ifdef LEVELDB_ATOMIC_PRESENT
+#if defined(LEVELDB_ATOMIC_PRESENT) || defined(OS_MACOSX)
 #include <atomic>
 #endif
 #ifdef OS_WIN
 #include <windows.h>
-#endif
-#ifdef OS_MACOSX
-#include <libkern/OSAtomic.h>
 #endif
 
 #if defined(_M_X64) || defined(__x86_64__)
@@ -80,7 +77,7 @@ class AtomicPointer {
 // Mac OS
 #elif defined(OS_MACOSX)
 inline void MemoryBarrier() {
-  OSMemoryBarrier();
+  std::atomic_thread_fence(std::memory_order_seq_cst);
 }
 #define LEVELDB_HAVE_MEMORY_BARRIER
 


### PR DESCRIPTION
It said:
```
./port/atomic_pointer.h:55:3: warning: 'OSMemoryBarrier' is deprecated: first
      deprecated in macOS 10.12 - Use std::atomic_thread_fence() from <atomic>
      instead [-Wdeprecated-declarations]
  OSMemoryBarrier();
```

The upstream LevelDB already replaced it with `std::atomic_thread_fence(std::memory_order_seq_cst);`

In addition, I found the definition of `OSMemoryBarrier()`, it calls the same function:

```
OSATOMIC_INLINE
void
OSMemoryBarrier(void)
{
	OSATOMIC_STD(atomic_thread_fence)(OSATOMIC_STD(memory_order_seq_cst));
}
```