### PR TITLE
Fix -Wsign-compare warning in logging.cc

### DIFF
--- a/util/logging.cc
+++ b/util/logging.cc
@@ -52,7 +52,7 @@ bool ConsumeDecimalNumber(Slice* in, uint64_t* val) {
     unsigned char c = (*in)[0];
     if (c >= '0' && c <= '9') {
       ++digits;
-      const int delta = (c - '0');
+      const long unsigned int delta = (c - '0');
       static const uint64_t kMaxUint64 = ~static_cast<uint64_t>(0);
       if (v > kMaxUint64/10 ||
           (v == kMaxUint64/10 && delta > kMaxUint64%10)) {


### PR DESCRIPTION
When compiling Bitcoin Core with `g++ (Debian 8.3.0-6) 8.3.0`
I get the following warning
```
leveldb/util/logging.cc:59:40: warning: comparison of integer expressions of different signedness: ‘const int’ and ‘uint64_t’ {aka ‘long unsigned int’} [-Wsign-compare]
```
This PR fixes it.
I also hope this is the correct repo to submit this PR