### PR TITLE
fix macro HAVE_O_CLOEXEC when O_CLOEXEC not found

### DIFF
--- a/util/env_posix.cc
+++ b/util/env_posix.cc
@@ -49,7 +49,7 @@ constexpr const int kDefaultMmapLimit = (sizeof(void*) >= 8) ? 4096 : 0;
 int g_mmap_limit = kDefaultMmapLimit;
 
 // Common flags defined for all posix open operations
-#if defined(HAVE_O_CLOEXEC)
+#if HAVE_O_CLOEXEC
 constexpr const int kOpenBaseFlags = O_CLOEXEC;
 #else
 constexpr const int kOpenBaseFlags = 0;


### PR DESCRIPTION
https://github.com/google/leveldb/pull/624 was [buggy](https://github.com/google/leveldb/pull/624#discussion_r901465515).

One bug was fixed in https://github.com/google/leveldb/commit/27dc99fb2642cadc87c9aaec82c54a2c725ee0d6.

https://github.com/google/leveldb/pull/1028 addresses another one.

This PR cherry-picks from https://github.com/google/leveldb/pull/1028, and is an alternative to https://github.com/bitcoin/bitcoin/pull/25463.