### PR TITLE
tidy: Fix clang-tidy errors in src/leveldb

### DIFF
--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -46,9 +46,9 @@ struct DBImpl::Writer {
       : batch(nullptr), sync(false), done(false), cv(mu) {}
 
   Status status;
-  WriteBatch* batch;
-  bool sync;
-  bool done;
+  WriteBatch* batch{nullptr};
+  bool sync{false};
+  bool done{false};
   port::CondVar cv;
 };
 
@@ -75,15 +75,15 @@ struct DBImpl::CompactionState {
   // will never have to service a snapshot below smallest_snapshot.
   // Therefore if we have seen a sequence number S <= smallest_snapshot,
   // we can drop all entries for the same key with sequence numbers < S.
-  SequenceNumber smallest_snapshot;
+  SequenceNumber smallest_snapshot{0};
 
   std::vector<Output> outputs;
 
   // State kept for output being generated
-  WritableFile* outfile;
-  TableBuilder* builder;
+  WritableFile* outfile{nullptr};
+  TableBuilder* builder{nullptr};
 
-  uint64_t total_bytes;
+  uint64_t total_bytes{0};
 };
 
 // Fix user-supplied options to be reasonable

--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -43,7 +43,7 @@ const int kNumNonTableCacheFiles = 10;
 // Information kept for every waiting writer
 struct DBImpl::Writer {
   explicit Writer(port::Mutex* mu)
-      : batch(nullptr), sync(false), done(false), cv(mu) {}
+      : cv(mu) {}
 
   Status status;
   WriteBatch* batch{nullptr};
@@ -63,11 +63,7 @@ struct DBImpl::CompactionState {
   Output* current_output() { return &outputs[outputs.size() - 1]; }
 
   explicit CompactionState(Compaction* c)
-      : compaction(c),
-        smallest_snapshot(0),
-        outfile(nullptr),
-        builder(nullptr),
-        total_bytes(0) {}
+      : compaction(c) {}
 
   Compaction* const compaction;
 

--- a/db/db_iter.cc
+++ b/db/db_iter.cc
@@ -51,8 +51,6 @@ class DBIter : public Iterator {
         user_comparator_(cmp),
         iter_(iter),
         sequence_(s),
-        direction_(kForward),
-        valid_(false),
         rnd_(seed),
         bytes_until_read_sampling_(RandomCompactionPeriod()) {}
 

--- a/db/db_iter.cc
+++ b/db/db_iter.cc
@@ -113,8 +113,8 @@ class DBIter : public Iterator {
   Status status_;
   std::string saved_key_;    // == current key when direction_==kReverse
   std::string saved_value_;  // == current raw value when direction_==kReverse
-  Direction direction_;
-  bool valid_;
+  Direction direction_{kForward};
+  bool valid_{false};
   Random rnd_;
   size_t bytes_until_read_sampling_;
 };

--- a/db/repair.cc
+++ b/db/repair.cc
@@ -51,8 +51,7 @@ class Repairer {
         ipolicy_(options.filter_policy),
         options_(SanitizeOptions(dbname, &icmp_, &ipolicy_, options)),
         owns_info_log_(options_.info_log != options.info_log),
-        owns_cache_(options_.block_cache != options.block_cache),
-        next_file_number_(1) {
+        owns_cache_(options_.block_cache != options.block_cache) {
     // TableCache can be small since we expect each table to be opened once.
     table_cache_ = new TableCache(dbname_, options_, 10);
   }

--- a/db/repair.cc
+++ b/db/repair.cc
@@ -438,7 +438,7 @@ class Repairer {
   std::vector<uint64_t> table_numbers_;
   std::vector<uint64_t> logs_;
   std::vector<TableInfo> tables_;
-  uint64_t next_file_number_;
+  uint64_t next_file_number_{1};
 };
 }  // namespace
 

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -1368,7 +1368,7 @@ void AddBoundaryInputs(const InternalKeyComparator& icmp,
         FindSmallestBoundaryFile(icmp, level_files, largest_key);
 
     // If a boundary file was found advance largest_key, otherwise we're done.
-    if (smallest_boundary_file != NULL) {
+    if (smallest_boundary_file != nullptr) {
       compaction_files->push_back(smallest_boundary_file);
       largest_key = smallest_boundary_file->largest;
     } else {

--- a/helpers/memenv/memenv.cc
+++ b/helpers/memenv/memenv.cc
@@ -143,11 +143,11 @@ class FileState {
   ~FileState() { Truncate(); }
 
   port::Mutex refs_mutex_;
-  int refs_ GUARDED_BY(refs_mutex_);
+  int refs_{0}; GUARDED_BY(refs_mutex_);
 
   mutable port::Mutex blocks_mutex_;
   std::vector<char*> blocks_ GUARDED_BY(blocks_mutex_);
-  uint64_t size_ GUARDED_BY(blocks_mutex_);
+  uint64_t size_{0}; GUARDED_BY(blocks_mutex_);
 };
 
 class SequentialFileImpl : public SequentialFile {
@@ -181,7 +181,7 @@ class SequentialFileImpl : public SequentialFile {
   virtual std::string GetName() const override { return "[memenv]"; }
  private:
   FileState* file_;
-  uint64_t pos_;
+  uint64_t pos_{0};
 };
 
 class RandomAccessFileImpl : public RandomAccessFile {

--- a/helpers/memenv/memenv.cc
+++ b/helpers/memenv/memenv.cc
@@ -25,7 +25,7 @@ class FileState {
  public:
   // FileStates are reference counted. The initial reference count is zero
   // and the caller must call Ref() at least once.
-  FileState() : refs_(0), size_(0) {}
+  FileState() {}
 
   // No copying allowed.
   FileState(const FileState&) = delete;
@@ -152,7 +152,7 @@ class FileState {
 
 class SequentialFileImpl : public SequentialFile {
  public:
-  explicit SequentialFileImpl(FileState* file) : file_(file), pos_(0) {
+  explicit SequentialFileImpl(FileState* file) : file_(file) {
     file_->Ref();
   }
 

--- a/table/merger.cc
+++ b/table/merger.cc
@@ -16,9 +16,7 @@ class MergingIterator : public Iterator {
   MergingIterator(const Comparator* comparator, Iterator** children, int n)
       : comparator_(comparator),
         children_(new IteratorWrapper[n]),
-        n_(n),
-        current_(nullptr),
-        direction_(kForward) {
+        n_(n) {
     for (int i = 0; i < n; i++) {
       children_[i].Set(children[i]);
     }

--- a/table/merger.cc
+++ b/table/merger.cc
@@ -141,8 +141,8 @@ class MergingIterator : public Iterator {
   const Comparator* comparator_;
   IteratorWrapper* children_;
   int n_;
-  IteratorWrapper* current_;
-  Direction direction_;
+  IteratorWrapper* current_{nullptr};
+  Direction direction_{kForward};
 };
 
 void MergingIterator::FindSmallest() {

--- a/table/table_builder.cc
+++ b/table/table_builder.cc
@@ -23,15 +23,11 @@ struct TableBuilder::Rep {
       : options(opt),
         index_block_options(opt),
         file(f),
-        offset(0),
         data_block(&options),
         index_block(&index_block_options),
-        num_entries(0),
-        closed(false),
         filter_block(opt.filter_policy == nullptr
                          ? nullptr
-                         : new FilterBlockBuilder(opt.filter_policy)),
-        pending_index_entry(false) {
+                         : new FilterBlockBuilder(opt.filter_policy)) {
     index_block_options.block_restart_interval = 1;
   }
 

--- a/table/table_builder.cc
+++ b/table/table_builder.cc
@@ -38,13 +38,13 @@ struct TableBuilder::Rep {
   Options options;
   Options index_block_options;
   WritableFile* file;
-  uint64_t offset;
+  uint64_t offset{0};
   Status status;
   BlockBuilder data_block;
   BlockBuilder index_block;
   std::string last_key;
-  int64_t num_entries;
-  bool closed;  // Either Finish() or Abandon() has been called.
+  int64_t num_entries{0};
+  bool closed{false};  // Either Finish() or Abandon() has been called.
   FilterBlockBuilder* filter_block;
 
   // We do not emit the index entry for a block until we have seen the
@@ -56,7 +56,7 @@ struct TableBuilder::Rep {
   // blocks.
   //
   // Invariant: r->pending_index_entry is true only if data_block is empty.
-  bool pending_index_entry;
+  bool pending_index_entry{false};
   BlockHandle pending_handle;  // Handle to add to index block
 
   std::string compressed_output;

--- a/util/cache.cc
+++ b/util/cache.cc
@@ -68,7 +68,7 @@ struct LRUHandle {
 // 4.4.3's builtin hashtable.
 class HandleTable {
  public:
-  HandleTable() : length_(0), elems_(0), list_(nullptr) { Resize(); }
+  HandleTable() { Resize(); }
   ~HandleTable() { delete[] list_; }
 
   LRUHandle* Lookup(const Slice& key, uint32_t hash) {
@@ -194,7 +194,7 @@ class LRUCache {
   HandleTable table_ GUARDED_BY(mutex_);
 };
 
-LRUCache::LRUCache() : capacity_(0), usage_(0) {
+LRUCache::LRUCache() {
   // Make empty circular linked lists.
   lru_.next = &lru_;
   lru_.prev = &lru_;
@@ -348,7 +348,7 @@ class ShardedLRUCache : public Cache {
   static uint32_t Shard(uint32_t hash) { return hash >> (32 - kNumShardBits); }
 
  public:
-  explicit ShardedLRUCache(size_t capacity) : last_id_(0) {
+  explicit ShardedLRUCache(size_t capacity) {
     const size_t per_shard = (capacity + (kNumShards - 1)) / kNumShards;
     for (int s = 0; s < kNumShards; s++) {
       shard_[s].SetCapacity(per_shard);

--- a/util/cache.cc
+++ b/util/cache.cc
@@ -104,9 +104,9 @@ class HandleTable {
  private:
   // The table consists of an array of buckets where each bucket is
   // a linked list of cache entries that hash into the bucket.
-  uint32_t length_;
-  uint32_t elems_;
-  LRUHandle** list_;
+  uint32_t length_{0};
+  uint32_t elems_{0};
+  LRUHandle** list_{nullptr};
 
   // Return a pointer to slot that points to a cache entry that
   // matches key/hash.  If there is no such cache entry, return a
@@ -176,11 +176,11 @@ class LRUCache {
   bool FinishErase(LRUHandle* e) EXCLUSIVE_LOCKS_REQUIRED(mutex_);
 
   // Initialized before use.
-  size_t capacity_;
+  size_t capacity_{0};
 
   // mutex_ protects the following state.
   mutable port::Mutex mutex_;
-  size_t usage_ GUARDED_BY(mutex_);
+  size_t usage_{0}; GUARDED_BY(mutex_);
 
   // Dummy head of LRU list.
   // lru.prev is newest entry, lru.next is oldest entry.
@@ -339,7 +339,7 @@ class ShardedLRUCache : public Cache {
  private:
   LRUCache shard_[kNumShards];
   port::Mutex id_mutex_;
-  uint64_t last_id_;
+  uint64_t last_id_{0};
 
   static inline uint32_t HashSlice(const Slice& s) {
     return Hash(s.data(), s.size(), 0);

--- a/util/env_posix.cc
+++ b/util/env_posix.cc
@@ -441,7 +441,7 @@ class PosixWritableFile final : public WritableFile {
 
   // buf_[0, pos_ - 1] contains data to be written to fd_.
   char buf_[kWritableFileBufferSize];
-  size_t pos_;
+  size_t pos_{0};
   int fd_;
 
   const bool is_manifest_;  // True if the file's name starts with MANIFEST.
@@ -752,7 +752,7 @@ class PosixEnv : public Env {
 
   port::Mutex background_work_mutex_;
   port::CondVar background_work_cv_ GUARDED_BY(background_work_mutex_);
-  bool started_background_thread_ GUARDED_BY(background_work_mutex_);
+  bool started_background_thread_{false}; GUARDED_BY(background_work_mutex_);
 
   std::queue<BackgroundWorkItem> background_work_queue_
       GUARDED_BY(background_work_mutex_);

--- a/util/env_posix.cc
+++ b/util/env_posix.cc
@@ -255,8 +255,7 @@ class PosixMmapReadableFile final : public RandomAccessFile {
 class PosixWritableFile final : public WritableFile {
  public:
   PosixWritableFile(std::string filename, int fd)
-      : pos_(0),
-        fd_(fd),
+      : fd_(fd),
         is_manifest_(IsManifest(filename)),
         filename_(std::move(filename)),
         dirname_(Dirname(filename_)) {}
@@ -787,7 +786,6 @@ int MaxOpenFiles() {
 
 PosixEnv::PosixEnv()
     : background_work_cv_(&background_work_mutex_),
-      started_background_thread_(false),
       mmap_limiter_(MaxMmaps()),
       fd_limiter_(MaxOpenFiles()) {}
 


### PR DESCRIPTION
Moved from https://github.com/bitcoin/bitcoin/pull/25715

This PR fixes all the errors listed when running the clang-tidy operation as documented in the https://github.com/bitcoin/bitcoin/blob/master/doc/developer-notes.md#coding-style-c-named-arguments

Steps:

```bash
./autogen.sh && ./configure CC=clang CXX=clang++
make clean && bear -- make -j $(nproc)
( cd ./src/ && run-clang-tidy  -j $(nproc) )
```