### PR TITLE
win32: fix -Wmissing-field-initializers warnings

### DIFF
--- a/util/env_windows.cc
+++ b/util/env_windows.cc
@@ -194,7 +194,7 @@ class WindowsRandomAccessFile : public RandomAccessFile {
   Status Read(uint64_t offset, size_t n, Slice* result,
               char* scratch) const override {
     DWORD bytes_read = 0;
-    OVERLAPPED overlapped = {0};
+    OVERLAPPED overlapped = {};
 
     overlapped.OffsetHigh = static_cast<DWORD>(offset >> 32);
     overlapped.Offset = static_cast<DWORD>(offset);


### PR DESCRIPTION
When building with `-Wmissing-field-initializers`, the following warning is emitted:
```bash
leveldb/util/env_windows.cc: In member function ‘virtual leveldb::Status leveldb::{anonymous}::WindowsRandomAccessFile::Read(uint64_t, size_t, leveldb::Slice*, char*) const’:
leveldb/util/env_windows.cc:197:31: warning: missing initializer for member ‘_OVERLAPPED::InternalHigh’ [-Wmissing-field-initializers]
  197 |     OVERLAPPED overlapped = {0};
      |                               ^
leveldb/util/env_windows.cc:197:31: warning: missing initializer for member ‘_OVERLAPPED::<anonymous>’ [-Wmissing-field-initializers]
leveldb/util/env_windows.cc:197:31: warning: missing initializer for member ‘_OVERLAPPED::hEvent’ [-Wmissing-field-initializers]
```

Submitted upstream: https://github.com/google/leveldb/pull/1053