### PR TITLE
Fix C++23 compilation errors in leveldb

### DIFF
--- a/util/env_posix.cc
+++ b/util/env_posix.cc
@@ -854,7 +854,11 @@ class SingletonEnv {
 #endif  // !defined(NDEBUG)
     static_assert(sizeof(env_storage_) >= sizeof(EnvType),
                   "env_storage_ will not fit the Env");
-    static_assert(alignof(decltype(env_storage_)) >= alignof(EnvType),
+    static_assert(std::is_standard_layout_v<SingletonEnv<EnvType>>);
+    static_assert(
+        offsetof(SingletonEnv<EnvType>, env_storage_) % alignof(EnvType) == 0,
+        "env_storage_ does not meet the Env's alignment needs");
+    static_assert(alignof(SingletonEnv<EnvType>) % alignof(EnvType) == 0,
                   "env_storage_ does not meet the Env's alignment needs");
     new (&env_storage_) EnvType();
   }
@@ -872,8 +876,7 @@ class SingletonEnv {
   }
 
  private:
-  typename std::aligned_storage<sizeof(EnvType), alignof(EnvType)>::type
-      env_storage_;
+  alignas(EnvType) char env_storage_[sizeof(EnvType)];
 #if !defined(NDEBUG)
   static std::atomic<bool> env_initialized_;
 #endif  // !defined(NDEBUG)

--- a/util/env_posix.cc
+++ b/util/env_posix.cc
@@ -860,7 +860,7 @@ class SingletonEnv {
         "env_storage_ does not meet the Env's alignment needs");
     static_assert(alignof(SingletonEnv<EnvType>) % alignof(EnvType) == 0,
                   "env_storage_ does not meet the Env's alignment needs");
-    new (&env_storage_) EnvType();
+    new (env_storage_) EnvType();
   }
   ~SingletonEnv() = default;
 

--- a/util/env_windows.cc
+++ b/util/env_windows.cc
@@ -808,7 +808,7 @@ class SingletonEnv {
         "env_storage_ does not meet the Env's alignment needs");
     static_assert(alignof(SingletonEnv<EnvType>) % alignof(EnvType) == 0,
                   "env_storage_ does not meet the Env's alignment needs");
-    new (&env_storage_) EnvType();
+    new (env_storage_) EnvType();
   }
   ~SingletonEnv() = default;
 

--- a/util/env_windows.cc
+++ b/util/env_windows.cc
@@ -802,7 +802,11 @@ class SingletonEnv {
 #endif  // !defined(NDEBUG)
     static_assert(sizeof(env_storage_) >= sizeof(EnvType),
                   "env_storage_ will not fit the Env");
-    static_assert(alignof(decltype(env_storage_)) >= alignof(EnvType),
+    static_assert(std::is_standard_layout_v<SingletonEnv<EnvType>>);
+    static_assert(
+        offsetof(SingletonEnv<EnvType>, env_storage_) % alignof(EnvType) == 0,
+        "env_storage_ does not meet the Env's alignment needs");
+    static_assert(alignof(SingletonEnv<EnvType>) % alignof(EnvType) == 0,
                   "env_storage_ does not meet the Env's alignment needs");
     new (&env_storage_) EnvType();
   }
@@ -820,8 +824,7 @@ class SingletonEnv {
   }
 
  private:
-  typename std::aligned_storage<sizeof(EnvType), alignof(EnvType)>::type
-      env_storage_;
+  alignas(EnvType) char env_storage_[sizeof(EnvType)];
 #if !defined(NDEBUG)
   static std::atomic<bool> env_initialized_;
 #endif  // !defined(NDEBUG)

--- a/util/no_destructor.h
+++ b/util/no_destructor.h
@@ -28,7 +28,7 @@ class NoDestructor {
     static_assert(
         alignof(NoDestructor<InstanceType>) % alignof(InstanceType) == 0,
         "instance_storage_ does not meet the instance's alignment requirement");
-    new (&instance_storage_)
+    new (instance_storage_)
         InstanceType(std::forward<ConstructorArgTypes>(constructor_args)...);
   }
 

--- a/util/no_destructor.h
+++ b/util/no_destructor.h
@@ -5,6 +5,7 @@
 #ifndef STORAGE_LEVELDB_UTIL_NO_DESTRUCTOR_H_
 #define STORAGE_LEVELDB_UTIL_NO_DESTRUCTOR_H_
 
+#include <cstddef>
 #include <type_traits>
 #include <utility>
 
@@ -20,8 +21,12 @@ class NoDestructor {
   explicit NoDestructor(ConstructorArgTypes&&... constructor_args) {
     static_assert(sizeof(instance_storage_) >= sizeof(InstanceType),
                   "instance_storage_ is not large enough to hold the instance");
+    static_assert(std::is_standard_layout_v<NoDestructor<InstanceType>>);
     static_assert(
-        alignof(decltype(instance_storage_)) >= alignof(InstanceType),
+        offsetof(NoDestructor, instance_storage_) % alignof(InstanceType) == 0,
+        "instance_storage_ does not meet the instance's alignment requirement");
+    static_assert(
+        alignof(NoDestructor<InstanceType>) % alignof(InstanceType) == 0,
         "instance_storage_ does not meet the instance's alignment requirement");
     new (&instance_storage_)
         InstanceType(std::forward<ConstructorArgTypes>(constructor_args)...);
@@ -37,8 +42,7 @@ class NoDestructor {
   }
 
  private:
-  typename std::aligned_storage<sizeof(InstanceType),
-                                alignof(InstanceType)>::type instance_storage_;
+  alignas(InstanceType) char instance_storage_[sizeof(InstanceType)];
 };
 
 }  // namespace leveldb


### PR DESCRIPTION
Cherry-picks two commits from upstream (https://github.com/google/leveldb/commit/302786e211d1f2e6fd260261f642d03a91e5922c, https://github.com/google/leveldb/commit/e829478c6a3a55d8e5c1227e2678dcc18d518609), which remove the usage of `std::aligned_storage/std::aligned_union`. 

Note the first cherry-pick is not clean, because due to Google tooling issues, it accidently contained a revert of the prior two commits. See https://github.com/google/leveldb/pull/1249 for more details, as well as https://issues.chromium.org/issues/388068052.

Closes #43.