### PR TITLE
Add `Reserve` method for fixed-size write batches

### DIFF
--- a/db/write_batch.cc
+++ b/db/write_batch.cc
@@ -37,6 +37,10 @@ void WriteBatch::Clear() {
   rep_.resize(kHeader);
 }
 
+void WriteBatch::Reserve(size_t size) {
+  rep_.reserve(size);
+}
+
 size_t WriteBatch::ApproximateSize() const { return rep_.size(); }
 
 Status WriteBatch::Iterate(Handler* handler) const {

--- a/db/write_batch_test.cc
+++ b/db/write_batch_test.cc
@@ -119,6 +119,14 @@ TEST(WriteBatchTest, ApproximateSize) {
   WriteBatch batch;
   size_t empty_size = batch.ApproximateSize();
 
+  // Reserve space for multiple operations
+  size_t expected_size = 35;
+  batch.Reserve(expected_size);
+
+  // The approximate size should still be the same as empty
+  // since Reserve doesn't affect the content size
+  ASSERT_EQ(empty_size, batch.ApproximateSize());
+
   batch.Put(Slice("foo"), Slice("bar"));
   size_t one_key_size = batch.ApproximateSize();
   ASSERT_LT(empty_size, one_key_size);
@@ -130,6 +138,8 @@ TEST(WriteBatchTest, ApproximateSize) {
   batch.Delete(Slice("box"));
   size_t post_delete_size = batch.ApproximateSize();
   ASSERT_LT(two_keys_size, post_delete_size);
+
+  ASSERT_EQ(expected_size, batch.ApproximateSize());
 }
 
 }  // namespace leveldb

--- a/include/leveldb/write_batch.h
+++ b/include/leveldb/write_batch.h
@@ -56,6 +56,9 @@ class LEVELDB_EXPORT WriteBatch {
   // Clear all updates buffered in this batch.
   void Clear();
 
+  // Preallocate memory for a batch containing a sequence of updates.
+  void Reserve(size_t size);
+
   // The size of the database changes caused by this batch.
   //
   // This number is tied to implementation details, and may change across


### PR DESCRIPTION
Clone of https://github.com/google/leveldb/pull/1259

> In case of Bitcoin Core the batch sizes at the final UTXO set are fixed (16 MiB currently).
This could enable us [pre-sizing the batch](https://github.com/bitcoin/bitcoin/blob/master/src/txdb.cpp#L94), if we had access to such a method, to avoid increasing memory copies at a critical time, when the memory is already saturated maximally - see https://github.com/bitcoin-dev-tools/benchcoin/pull/136.