### PR TITLE
Remove workaround for old Linux kernel CIFS bug

### DIFF
--- a/util/env_posix.cc
+++ b/util/env_posix.cc
@@ -325,7 +325,7 @@ class PosixWritableFile final : public WritableFile {
       return status;
     }
 
-    return SyncFd(fd_, filename_, false);
+    return SyncFd(fd_, filename_);
   }
 
  private:
@@ -360,7 +360,7 @@ class PosixWritableFile final : public WritableFile {
     if (fd < 0) {
       status = PosixError(dirname_, errno);
     } else {
-      status = SyncFd(fd, dirname_, true);
+      status = SyncFd(fd, dirname_);
       ::close(fd);
     }
     return status;
@@ -372,7 +372,7 @@ class PosixWritableFile final : public WritableFile {
   //
   // The path argument is only used to populate the description string in the
   // returned Status if an error occurs.
-  static Status SyncFd(int fd, const std::string& fd_path, bool syncing_dir) {
+  static Status SyncFd(int fd, const std::string& fd_path) {
 #if HAVE_FULLFSYNC
     // On macOS and iOS, fsync() doesn't guarantee durability past power
     // failures. fcntl(F_FULLFSYNC) is required for that purpose. Some
@@ -390,11 +390,6 @@ class PosixWritableFile final : public WritableFile {
 #endif  // HAVE_FDATASYNC
 
     if (sync_success) {
-      return Status::OK();
-    }
-    // Do not crash if filesystem can't fsync directories
-    // (see https://github.com/bitcoin/bitcoin/pull/10000)
-    if (syncing_dir && errno == EINVAL) {
       return Status::OK();
     }
     return PosixError(fd_path, errno);


### PR DESCRIPTION
A long time ago (https://github.com/bitcoin/bitcoin/pull/10000) we added a workaround for a Linux kernel issue where calling `fsync` on a directory would instantly and reliably fail for CIFS mounts. In 2018 i ported this forward to the new leveldb tree (https://github.com/bitcoin-core/leveldb-subtree/commit/d42e63d49d9df05b12cd00af4ffc5f2b3edf7e21) without checking if it would still be necessary. Nearly a decade later it's time to reevaluate this.

This is an ugly workaround (always intended to be temporary) as the code isn't written specifically: If directory sync fails on a correctly working filesystem it ignores this as well, potentially ignoring a real problem. Although checking for errno==EINVAL partially mitigates this, it would be preferable to get rid of it. See also https://github.com/google/leveldb/pull/1262 . 

So just today i did some experiment to check:

```c++
// Test case for directory synchronization on CIFS share.
// SPDX-License-Identifier: MIT
//
// Usage: fsynctest <cifs_mount_path>/testdir
#include <fcntl.h>
#include <stdio.h>
#include <stdlib.h>
#include <unistd.h>

int main(int argc, char **argv)
{
    if (argc != 2) {
        fprintf(stderr, "missing arg\n");
        exit(1);
    }
    int fd = open(argv[1], O_DIRECTORY | O_RDONLY); // O_DIRECTORY just ensures that this can't be run on files.
    if (fd < 0) {
        perror("open");
        exit(1);
    }

    int res;

    fprintf(stderr, "performing fsync on directory... ");
    res = fsync(fd);
    if (res == 0) {
        fprintf(stderr, "ok\n");
    } else {
        perror("");
    }

    fprintf(stderr, "performing fdatasync on directory... ");
    res = fdatasync(fd);
    if (res == 0) {
        fprintf(stderr, "ok\n");
    } else {
        perror("");
    }

    close(fd);
}
```

and ran this on a CIFS share:
```
$ findmnt /storage/synctest
TARGET         SOURCE          FSTYPE OPTIONS
/storage/synctest //storage/... cifs   rw,relatime,vers=3.1.1,...
$ ./fsynctest /storage/synctest/synctest/
performing fsync on directory... ok
performing fdatasync on directory... ok
```
At least at first glance (some more testing might or might not be warranted), the original problem doesn't appear to exist anymore.

Versions:
- client: kernel 6.8.0, smbd 4.19.5
- server: kernel 6.6.31, smbd 4.17.12

This reverts commit d42e63d49d9df05b12cd00af4ffc5f2b3edf7e21.
