### PR TITLE
refactor: add missing overrides

### DIFF
--- a/db/c.cc
+++ b/db/c.cc
@@ -471,11 +471,11 @@ leveldb_filterpolicy_t* leveldb_filterpolicy_create_bloom(int bits_per_key) {
     static void DoNothing(void*) {}
 
     ~Wrapper() { delete rep_; }
-    const char* Name() const { return rep_->Name(); }
-    void CreateFilter(const Slice* keys, int n, std::string* dst) const {
+    const char* Name() const override { return rep_->Name(); }
+    void CreateFilter(const Slice* keys, int n, std::string* dst) const override {
       return rep_->CreateFilter(keys, n, dst);
     }
-    bool KeyMayMatch(const Slice& key, const Slice& filter) const {
+    bool KeyMayMatch(const Slice& key, const Slice& filter) const override {
       return rep_->KeyMayMatch(key, filter);
     }
 

--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -139,7 +139,7 @@ class SpecialEnv : public EnvWrapper {
      public:
       DataFile(SpecialEnv* env, WritableFile* base) : env_(env), base_(base) {}
       ~DataFile() { delete base_; }
-      Status Append(const Slice& data) {
+      Status Append(const Slice& data) override {
         if (env_->no_space_.load(std::memory_order_acquire)) {
           // Drop writes on the floor
           return Status::OK();
@@ -147,9 +147,9 @@ class SpecialEnv : public EnvWrapper {
           return base_->Append(data);
         }
       }
-      Status Close() { return base_->Close(); }
-      Status Flush() { return base_->Flush(); }
-      Status Sync() {
+      Status Close() override { return base_->Close(); }
+      Status Flush() override { return base_->Flush(); }
+      Status Sync() override {
         if (env_->data_sync_error_.load(std::memory_order_acquire)) {
           return Status::IOError("simulated data sync error");
         }
@@ -168,16 +168,16 @@ class SpecialEnv : public EnvWrapper {
      public:
       ManifestFile(SpecialEnv* env, WritableFile* b) : env_(env), base_(b) {}
       ~ManifestFile() { delete base_; }
-      Status Append(const Slice& data) {
+      Status Append(const Slice& data) override {
         if (env_->manifest_write_error_.load(std::memory_order_acquire)) {
           return Status::IOError("simulated writer error");
         } else {
           return base_->Append(data);
         }
       }
-      Status Close() { return base_->Close(); }
-      Status Flush() { return base_->Flush(); }
-      Status Sync() {
+      Status Close() override { return base_->Close(); }
+      Status Flush() override { return base_->Flush(); }
+      Status Sync() override {
         if (env_->manifest_sync_error_.load(std::memory_order_acquire)) {
           return Status::IOError("simulated sync error");
         } else {

--- a/db/log_test.cc
+++ b/db/log_test.cc
@@ -205,7 +205,7 @@ class LogTest {
 
       return Status::OK();
     }
-    std::string GetName() const { return ""; }
+    std::string GetName() const override { return ""; }
 
     Slice contents_;
     bool force_error_;

--- a/table/table_test.cc
+++ b/table/table_test.cc
@@ -129,7 +129,7 @@ class StringSource : public RandomAccessFile {
     return Status::OK();
   }
 
-  std::string GetName() const { return ""; }
+  std::string GetName() const override { return ""; }
  private:
   std::string contents_;
 };


### PR DESCRIPTION
Fixes instances of:
```bash
leveldb-subtree/db/log_test.cc:208:17: error: 'GetName' overrides a member function but is not marked 'override' [-Werror,-Winconsistent-missing-override]
  208 |     std::string GetName() const { return ""; }
```

To fix compile failures under C++20, and removing warning supression in the main repo.