### PR TITLE
Revert "Increase maximum read-only mmap()s used from 1000 to 4096 on 64-bit systems"

### DIFF
--- a/util/env_posix.cc
+++ b/util/env_posix.cc
@@ -42,8 +42,8 @@ namespace {
 // Set by EnvPosixTestHelper::SetReadOnlyMMapLimit() and MaxOpenFiles().
 int g_open_read_only_file_limit = -1;
 
-// Up to 4096 mmap regions for 64-bit binaries; none for 32-bit.
-constexpr const int kDefaultMmapLimit = (sizeof(void*) >= 8) ? 4096 : 0;
+// Up to 1000 mmap regions for 64-bit binaries; none for 32-bit.
+constexpr const int kDefaultMmapLimit = (sizeof(void*) >= 8) ? 1000 : 0;
 
 // Can be set using EnvPosixTestHelper::SetReadOnlyMMapLimit().
 int g_mmap_limit = kDefaultMmapLimit;


### PR DESCRIPTION
After bitcoin/bitcoin#30039, the number of ldb files created is 16 times smaller. 1000 files with the new default of 32MB is 32GB of database.

If we need more (for good performance), we can increase the default file size again.

This patch seems unnecessary now.

This reverts commit 92ae82c78f225de84040c51e07fd0b4a61caed99:

> By default LevelDB will only mmap() up to 1000 ldb files for reading and then fall back
to using file desciptors.
>
> The typical linux system has a 'vm.max_map_count = 65530', so mapping only 1000 files
seems arbitarily small. Increase this value to another arbitrarily small value, 4096.
