### PR TITLE
refactor: Delete unused `ScopedHandle:operator=(ScopedHandle&&)`

### DIFF
--- a/util/env_windows.cc
+++ b/util/env_windows.cc
@@ -81,10 +81,7 @@ class ScopedHandle {
 
   ScopedHandle& operator=(const ScopedHandle&) = delete;
 
-  ScopedHandle& operator=(ScopedHandle&& rhs) noexcept {
-    if (this != &rhs) handle_ = rhs.Release();
-    return *this;
-  }
+  ScopedHandle& operator=(ScopedHandle&& rhs) = delete;
 
   bool Close() {
     if (!is_valid()) {


### PR DESCRIPTION
This PR removes the unused move-assignment operator to silence the `-Wunused-member-function` warning emitted by clang-cl:
```
D:\a\bitcoin\bitcoin\src\leveldb\util\env_windows.cc(84,17): error : unused member function 'operator=' [-Werror,-Wunused-member-function] [D:\a\bitcoin\bitcoin\build\src\leveldb.vcxproj]
```

This warning was noted during work on https://github.com/bitcoin/bitcoin/pull/31507, where it was [suggested](https://github.com/bitcoin/bitcoin/pull/31507#discussion_r1990498934) that addressing it might be worthwhile.

Alternatively, the warning could be suppressed [downstream](https://github.com/bitcoin/bitcoin/pull/31507#discussion_r1990498934), but this change avoids the need for that.

There appears to be [little justification](https://github.com/google/leveldb?tab=readme-ov-file#contributing-to-the-leveldb-project) for submitting this upstream.