### PR TITLE
Remove uninitialized `bytes_written` statistics from `CompactionStats`

### DIFF
--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -537,7 +537,6 @@ Status DBImpl::WriteLevel0Table(MemTable* mem, VersionEdit* edit,
 
   CompactionStats stats;
   stats.micros = env_->NowMicros() - start_micros;
-  stats.bytes_written = meta.file_size;
   stats_[level].Add(stats);
   return s;
 }
@@ -1028,9 +1027,6 @@ Status DBImpl::DoCompactionWork(CompactionState* compact) {
       stats.bytes_read += compact->compaction->input(which, i)->file_size;
     }
   }
-  for (size_t i = 0; i < compact->outputs.size(); i++) {
-    stats.bytes_written += compact->outputs[i].file_size;
-  }
 
   mutex_.Lock();
   stats_[compact->compaction->level() + 1].Add(stats);
@@ -1412,11 +1408,10 @@ bool DBImpl::GetProperty(const Slice& property, std::string* value) {
     for (int level = 0; level < config::kNumLevels; level++) {
       int files = versions_->NumLevelFiles(level);
       if (stats_[level].micros > 0 || files > 0) {
-        snprintf(buf, sizeof(buf), "%3d %8d %8.0f %9.0f %8.0f %9.0f\n", level,
+        snprintf(buf, sizeof(buf), "%3d %8d %8.0f %9.0f %8.0f\n", level,
                  files, versions_->NumLevelBytes(level) / 1048576.0,
                  stats_[level].micros / 1e6,
-                 stats_[level].bytes_read / 1048576.0,
-                 stats_[level].bytes_written / 1048576.0);
+                 stats_[level].bytes_read / 1048576.0);
         value->append(buf);
       }
     }

--- a/db/db_impl.h
+++ b/db/db_impl.h
@@ -88,17 +88,15 @@ class DBImpl : public DB {
   // Per level compaction stats.  stats_[level] stores the stats for
   // compactions that produced data for the specified "level".
   struct CompactionStats {
-    CompactionStats() : micros(0), bytes_read(0), bytes_written(0) {}
+    CompactionStats() : micros(0), bytes_read(0) {}
 
     void Add(const CompactionStats& c) {
       this->micros += c.micros;
       this->bytes_read += c.bytes_read;
-      this->bytes_written += c.bytes_written;
     }
 
     int64_t micros;
     int64_t bytes_read;
-    int64_t bytes_written;
   };
 
   Iterator* NewInternalIterator(const ReadOptions&,

--- a/util/env_posix.cc
+++ b/util/env_posix.cc
@@ -854,7 +854,8 @@ class SingletonEnv {
 #endif  // !defined(NDEBUG)
     static_assert(sizeof(env_storage_) >= sizeof(EnvType),
                   "env_storage_ will not fit the Env");
-    static_assert(std::is_standard_layout_v<SingletonEnv<EnvType>>);
+    static_assert(std::is_standard_layout<SingletonEnv<EnvType>>::value,
+                  "SingletonEnv<EnvType> must have standard layout");
     static_assert(
         offsetof(SingletonEnv<EnvType>, env_storage_) % alignof(EnvType) == 0,
         "env_storage_ does not meet the Env's alignment needs");

--- a/util/no_destructor.h
+++ b/util/no_destructor.h
@@ -21,7 +21,8 @@ class NoDestructor {
   explicit NoDestructor(ConstructorArgTypes&&... constructor_args) {
     static_assert(sizeof(instance_storage_) >= sizeof(InstanceType),
                   "instance_storage_ is not large enough to hold the instance");
-    static_assert(std::is_standard_layout_v<NoDestructor<InstanceType>>);
+    static_assert(std::is_standard_layout<NoDestructor<InstanceType>>::value,
+                  "NoDestructor<InstanceType> must have standard layout");
     static_assert(
         offsetof(NoDestructor, instance_storage_) % alignof(InstanceType) == 0,
         "instance_storage_ does not meet the instance's alignment requirement");


### PR DESCRIPTION
The `bytes_written` field from `CompactionStats` was reading uninitialized memory, causing undefined behavior detected by UBSan, as reported in https://github.com/bitcoin/bitcoin/pull/28359#issuecomment-1698694748

This would simplify the Bitcoin Core CI in https://github.com/l0rinc/bitcoin/blob/7cc9a087069bfcdb79a08ce77eb3a60adf9483af/ci/test/03_test_script.sh#L36-L56

Can be tested with (`corruption_test` covers the modified line):
```bash
cmake -B build && cmake --build build -j$(nproc) && ctest --test-dir build -j$(nproc)
```