### PR TITLE
 Initialize file_size to 0 to avoid UB 

### DIFF
--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -803,6 +803,7 @@ Status DBImpl::OpenCompactionOutputFile(CompactionState* compact) {
     pending_outputs_.insert(file_number);
     CompactionState::Output out;
     out.number = file_number;
+    out.file_size = 0;
     out.smallest.Clear();
     out.largest.Clear();
     compact->outputs.push_back(out);


### PR DESCRIPTION
Fixes https://github.com/bitcoin-core/leveldb-subtree/issues/37.

Now that basically all sanitizer complain about this, and no one has submitted a fix upstream, initialize file_size to 0 to avoid UB.

This is trivially correct, because UB can be optimized into that by the compiler anyway.

GCC-16 seems to be detecting this by default, so it is time to do something about it.


```
In copy constructor 'constexpr leveldb::DBImpl::CompactionState::Output::Output(const leveldb::DBImpl::CompactionState::Output&)',
    inlined from 'constexpr _Tp* std::construct_at(_Tp*, _Args&& ...) [with _Tp = leveldb::DBImpl::CompactionState::Output; _Args = {const leveldb::DBImpl::CompactionState::Output&}]' at /usr/include/c++/16/bits/stl_construct.h:110:9,
    inlined from 'static constexpr void std::allocator_traits<std::allocator<_Up> >::construct(allocator_type&, _Up*, _Args&& ...) [with _Up = leveldb::DBImpl::CompactionState::Output; _Args = {const leveldb::DBImpl::CompactionState::Output&}; _Tp = leveldb::DBImpl::CompactionState::Output]' at /usr/include/c++/16/bits/alloc_traits.h:676:21,
    inlined from 'constexpr void std::vector<_Tp, _Alloc>::push_back(const value_type&) [with _Tp = leveldb::DBImpl::CompactionState::Output; _Alloc = std::allocator<leveldb::DBImpl::CompactionState::Output>]' at /usr/include/c++/16/bits/stl_vector.h:1411:30,
    inlined from 'leveldb::Status leveldb::DBImpl::OpenCompactionOutputFile(CompactionState*)' at /__w/bitcoin-core-nightly/bitcoin-core-nightly/src/leveldb/db/db_impl.cc:808:31:
/__w/bitcoin-core-nightly/bitcoin-core-nightly/src/leveldb/db/db_impl.cc:57:10: error: 'out.leveldb::DBImpl::CompactionState::Output::file_size' may be used uninitialized [-Werror=maybe-uninitialized]
   57 |   struct Output {
      |          ^~~~~~
/__w/bitcoin-core-nightly/bitcoin-core-nightly/src/leveldb/db/db_impl.cc: In member function 'leveldb::Status leveldb::DBImpl::OpenCompactionOutputFile(CompactionState*)':
/__w/bitcoin-core-nightly/bitcoin-core-nightly/src/leveldb/db/db_impl.cc:804:29: note: 'out' declared here
  804 |     CompactionState::Output out;
      |                             ^~~
In copy constructor 'constexpr leveldb::DBImpl::CompactionState::Output::Output(const leveldb::DBImpl::CompactionState::Output&)',
    inlined from 'constexpr _Tp* std::construct_at(_Tp*, _Args&& ...) [with _Tp = leveldb::DBImpl::CompactionState::Output; _Args = {const leveldb::DBImpl::CompactionState::Output&}]' at /usr/include/c++/16/bits/stl_construct.h:110:9,
    inlined from 'static constexpr void std::allocator_traits<std::allocator<_Up> >::construct(allocator_type&, _Up*, _Args&& ...) [with _Up = leveldb::DBImpl::CompactionState::Output; _Args = {const leveldb::DBImpl::CompactionState::Output&}; _Tp = leveldb::DBImpl::CompactionState::Output]' at /usr/include/c++/16/bits/alloc_traits.h:676:21,
    inlined from 'constexpr void std::vector<_Tp, _Alloc>::_M_realloc_append(_Args&& ...) [with _Args = {const leveldb::DBImpl::CompactionState::Output&}; _Tp = leveldb::DBImpl::CompactionState::Output; _Alloc = std::allocator<leveldb::DBImpl::CompactionState::Output>]' at /usr/include/c++/16/bits/vector.tcc:594:26,
    inlined from 'constexpr void std::vector<_Tp, _Alloc>::push_back(const value_type&) [with _Tp = leveldb::DBImpl::CompactionState::Output; _Alloc = std::allocator<leveldb::DBImpl::CompactionState::Output>]' at /usr/include/c++/16/bits/stl_vector.h:1417:21,
    inlined from 'leveldb::Status leveldb::DBImpl::OpenCompactionOutputFile(CompactionState*)' at /__w/bitcoin-core-nightly/bitcoin-core-nightly/src/leveldb/db/db_impl.cc:808:31:
/__w/bitcoin-core-nightly/bitcoin-core-nightly/src/leveldb/db/db_impl.cc:57:10: error: 'out.leveldb::DBImpl::CompactionState::Output::file_size' may be used uninitialized [-Werror=maybe-uninitialized]
   57 |   struct Output {
      |          ^~~~~~
/__w/bitcoin-core-nightly/bitcoin-core-nightly/src/leveldb/db/db_impl.cc: In member function 'leveldb::Status leveldb::DBImpl::OpenCompactionOutputFile(CompactionState*)':
/__w/bitcoin-core-nightly/bitcoin-core-nightly/src/leveldb/db/db_impl.cc:804:29: note: 'out' declared here
  804 |     CompactionState::Output out;
      |                             ^~~
cc1plus: all warnings being treated as errors
gmake[2]: *** [src/CMakeFiles/leveldb.dir/build.make:107: src/CMakeFiles/leveldb.dir/leveldb/db/db_impl.cc.o] Error 1