### PR TITLE
Fix Clang `-Wconditional-uninitialized` warning

### DIFF
--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -994,7 +994,7 @@ bool VersionSet::ReuseManifest(const std::string& dscname,
   }
   FileType manifest_type;
   uint64_t manifest_number;
-  uint64_t manifest_size;
+  uint64_t manifest_size = 0;
   if (!ParseFileName(dscbase, &manifest_number, &manifest_type) ||
       manifest_type != kDescriptorFile ||
       !env_->GetFileSize(dscname, &manifest_size).ok() ||


### PR DESCRIPTION
Steps to reproduce the warning on Ubuntu 25.10 using Clang 22.0:
1. Apply a diff to workaround a build [issue](https://github.com/bitcoin-core/leveldb-subtree/pull/55):
```diff
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ set(CMAKE_C_STANDARD_REQUIRED OFF)
 set(CMAKE_C_EXTENSIONS OFF)
 
 # This project requires C++11.
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
```
2. Configure:
```
$ cmake -B build -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_CXX_FLAGS=-Wconditional-uninitialized -DLEVELDB_BUILD_BENCHMARKS=ON
```
3. Build:
```
$ cmake --build build
[23/161] Building CXX object CMakeFiles/leveldb.dir/db/version_set.cc.o
FAILED: CMakeFiles/leveldb.dir/db/version_set.cc.o 
/usr/bin/clang++ -DLEVELDB_COMPILE_LIBRARY -DLEVELDB_PLATFORM_POSIX=1 -I/home/hebasto/dev/leveldb/build/include -I/home/hebasto/dev/leveldb/. -I/home/hebasto/dev/leveldb/include -Wconditional-uninitialized -fno-exceptions -fno-rtti -std=c++20 -Werror -Wthread-safety -MD -MT CMakeFiles/leveldb.dir/db/version_set.cc.o -MF CMakeFiles/leveldb.dir/db/version_set.cc.o.d -o CMakeFiles/leveldb.dir/db/version_set.cc.o -c /home/hebasto/dev/leveldb/db/version_set.cc
/home/hebasto/dev/leveldb/db/version_set.cc:1016:55: error: variable 'manifest_size' may be uninitialized when used here [-Werror,-Wconditional-uninitialized]
 1016 |   descriptor_log_ = new log::Writer(descriptor_file_, manifest_size);
      |                                                       ^~~~~~~~~~~~~
/home/hebasto/dev/leveldb/db/version_set.cc:997:25: note: initialize the variable 'manifest_size' to silence this warning
  997 |   uint64_t manifest_size;
      |                         ^
      |                          = 0
1 error generated.
[40/161] Building CXX object CMakeFiles/leveldb.dir/util/env_posix.cc.o
ninja: build stopped: subcommand failed.
hebasto@TS-P340:~/dev/leveldb
```

This eliminates the need for the following [code](https://github.com/bitcoin/bitcoin/blob/b58eebf1520f503bd4c7c5693546a6859064ce51/cmake/leveldb.cmake#L89-L92):
```cmake
else()
  try_append_cxx_flags("-Wconditional-uninitialized" TARGET nowarn_leveldb_interface SKIP_LINK
    IF_CHECK_PASSED "-Wno-conditional-uninitialized"
  )
```