### PR TITLE
util: use [[fallthrough]] directly

### DIFF
--- a/util/hash.cc
+++ b/util/hash.cc
@@ -8,15 +8,6 @@
 
 #include "util/coding.h"
 
-// The FALLTHROUGH_INTENDED macro can be used to annotate implicit fall-through
-// between switch labels. The real definition should be provided externally.
-// This one is a fallback version for unsupported compilers.
-#ifndef FALLTHROUGH_INTENDED
-#define FALLTHROUGH_INTENDED \
-  do {                       \
-  } while (0)
-#endif
-
 namespace leveldb {
 
 uint32_t Hash(const char* data, size_t n, uint32_t seed) {
@@ -39,10 +30,10 @@ uint32_t Hash(const char* data, size_t n, uint32_t seed) {
   switch (limit - data) {
     case 3:
       h += static_cast<uint8_t>(data[2]) << 16;
-      FALLTHROUGH_INTENDED;
+      [[fallthrough]];
     case 2:
       h += static_cast<uint8_t>(data[1]) << 8;
-      FALLTHROUGH_INTENDED;
+      [[fallthrough]];
     case 1:
       h += static_cast<uint8_t>(data[0]);
       h *= m;


### PR DESCRIPTION
Now that C++17 is required, there's no need to provide a fallback for unsupported compilers.