### PR TITLE
ci: Add LevelDB test workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,12 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - run: cmake -B build -DBUILD_SHARED_LIBS=OFF
+      - run: cmake --build build -j$(nproc)
+      - run: ctest --test-dir build --output-on-failure -j$(nproc)

--- a/benchmarks/db_bench_sqlite3.cc
+++ b/benchmarks/db_bench_sqlite3.cc
@@ -5,6 +5,7 @@
 #include <sqlite3.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <time.h>
 
 #include "util/histogram.h"
 #include "util/random.h"


### PR DESCRIPTION
**Problem:** GitHub PRs can currently be green without this subtree's `LevelDB` tests being built and run, so failures in tests such as `autocompact_test` and `db_test` can be missed.

**Fix:** Add a minimal `GitHub Actions` workflow for pushes and pull requests. It configures a static `CMake` build so the full test set is registered, builds the default targets including benchmarks, and runs `CTest` with failure output.

**Context:** I was wondering how https://github.com/bitcoin-core/leveldb-subtree/pull/61 can pass CI while disabling a seemingly important feature, and saw locally that two tests were failing.