### PR TITLE
Revert "Revert "Increase maximum read-only mmap()s used from 1000 to …

### DIFF
--- a/util/env_posix.cc
+++ b/util/env_posix.cc
@@ -42,8 +42,8 @@ namespace {
 // Set by EnvPosixTestHelper::SetReadOnlyMMapLimit() and MaxOpenFiles().
 int g_open_read_only_file_limit = -1;
 
-// Up to 1000 mmap regions for 64-bit binaries; none for 32-bit.
-constexpr const int kDefaultMmapLimit = (sizeof(void*) >= 8) ? 1000 : 0;
+// Up to 4096 mmap regions for 64-bit binaries; none for 32-bit.
+constexpr const int kDefaultMmapLimit = (sizeof(void*) >= 8) ? 4096 : 0;
 
 // Can be set using EnvPosixTestHelper::SetReadOnlyMMapLimit().
 int g_mmap_limit = kDefaultMmapLimit;


### PR DESCRIPTION
…4096 on 64-bit systems""

This reverts commit fd8f69657e0d2abd494018dc950776b96f9405c7.

The rationale for https://github.com/bitcoin-core/leveldb-subtree/pull/52 was that we reduced the file count, so the patch no longer seems necessary (it being a revert of the original patch https://github.com/bitcoin-core/leveldb-subtree/pull/19).

However, this patch in combination with #61 has caused performance regressions in https://github.com/bitcoin/bitcoin/ (see https://github.com/bitcoin/bitcoin/issues/35457). It has been speculated that this patch could reduce reported memory usage, but that seems to not be the case https://github.com/bitcoin/bitcoin/issues/33351#issuecomment-4565046750.

So, if the only rationale for #52 was to make this fork more closely aligned with upstream, then I don't think it's worth it if it's causing a performance regression. We should just revert it again to resolve the performance regressions.

Resolves https://github.com/bitcoin/bitcoin/issues/35457.
